### PR TITLE
ツイート投稿API（テキスト）を追加

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -28,3 +28,6 @@ RSpec/NamedSubject:
   Enabled: false
 RSpec/ExampleLength:
   Enabled: false
+RSpec/AnyInstance:
+  Exclude:
+    - "spec/**/*"

--- a/app/controllers/api/v1/tweets_controller.rb
+++ b/app/controllers/api/v1/tweets_controller.rb
@@ -13,6 +13,21 @@ module Api
         @tweets_paginated = tweets.page(offset).per(limit)
         @pagination = pagination(@tweets_paginated)
       end
+
+      def create
+        tweet = current_api_v1_user.tweets.build(tweet_params)
+        if tweet.save
+          render json: { tweet: tweet }, status: :created
+        else
+          render json: { errors: tweet.errors }, status: :unprocessable_entity
+        end
+      end
+
+      private
+
+      def tweet_params
+        params.permit(:tweet)
+      end
     end
   end
 end

--- a/app/controllers/api/v1/tweets_controller.rb
+++ b/app/controllers/api/v1/tweets_controller.rb
@@ -4,6 +4,7 @@ module Api
   module V1
     class TweetsController < ApplicationController
       include Pagination
+      before_action :authenticate_api_v1_user!, only: %i[index create]
 
       def index
         offset = params[:offset].presence || 1

--- a/app/controllers/api/v1/tweets_controller.rb
+++ b/app/controllers/api/v1/tweets_controller.rb
@@ -18,7 +18,7 @@ module Api
       def create
         tweet = current_api_v1_user.tweets.build(tweet_params)
         if tweet.save
-          render json: { tweet: tweet }, status: :created
+          render json: { tweet: }, status: :created
         else
           render json: { errors: tweet.errors }, status: :unprocessable_entity
         end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,7 @@ Rails.application.routes.draw do
         resources :sessions, only: [:index]
       end
 
-      resources :tweets, only: %i[index], format: 'json'
+      resources :tweets, only: %i[index create], format: 'json'
     end
   end
 end

--- a/spec/requests/api/v1/tweets_spec.rb
+++ b/spec/requests/api/v1/tweets_spec.rb
@@ -3,6 +3,11 @@
 require 'rails_helper'
 
 RSpec.describe 'Api::V1::Tweets', type: :request do
+  # 認証をスキップさせる
+  before do
+    allow_any_instance_of(Api::V1::TweetsController).to receive(:authenticate_api_v1_user!).and_return(true)
+  end
+
   describe 'GET /api/v1/tweets' do
     before do
       FactoryBot.create_list(:tweet, 20)

--- a/spec/requests/api/v1/tweets_spec.rb
+++ b/spec/requests/api/v1/tweets_spec.rb
@@ -28,4 +28,23 @@ RSpec.describe 'Api::V1::Tweets', type: :request do
       expect(pagination['current_page']).to eq 1
     end
   end
+
+  describe 'POST /api/v1/tweets' do
+    subject { post(api_v1_tweets_path, headers: headers, params: params) }
+    let!(:user) { FactoryBot.create(:user) }
+    let!(:params) { { tweet: 'テストツイート' } }
+
+    # 認証情報をヘッダーに付与する
+    before do
+      auth_token = user.create_new_auth_token
+      headers['access-token'] = auth_token['access-token']
+      headers['client'] = auth_token['client']
+      headers['uid'] = auth_token['uid']
+    end
+
+    it 'ツイートが投稿できること' do
+      subject
+      expect(response).to have_http_status(:created)
+    end
+  end
 end

--- a/spec/requests/api/v1/tweets_spec.rb
+++ b/spec/requests/api/v1/tweets_spec.rb
@@ -30,7 +30,8 @@ RSpec.describe 'Api::V1::Tweets', type: :request do
   end
 
   describe 'POST /api/v1/tweets' do
-    subject { post(api_v1_tweets_path, headers: headers, params: params) }
+    subject { post(api_v1_tweets_path, headers:, params:) }
+
     let!(:user) { FactoryBot.create(:user) }
     let!(:params) { { tweet: 'テストツイート' } }
 


### PR DESCRIPTION
## 課題のリンク

* https://github.com/happiness-chain/practice/blob/main/14.2_react/003_%E8%AA%B2%E9%A1%8C.md#%E3%83%84%E3%82%A4%E3%83%BC%E3%83%88%E6%8A%95%E7%A8%BF%E6%A9%9F%E8%83%BD

## やったこと

* ツイート投稿API（テキスト）を作成しました
* before_actionでログインチェックをしました

## やらなかったこと

* 画像投稿は別PRで対応するので、このPRに含まれません。

## 動作確認方法

* 動作確認はフロント実装後でも良さそう
* curlで確認するなら
  * [会員登録・ログイン](https://8tako8tako8.github.io/twitter_react/registration)後にCookieから `access-token`, `client`, 'uid' を取得
  * 以下のコマンドを叩く

```
curl 'https://twitter-rails-api1-a77730c5e74f.herokuapp.com/api/v1/tweets' \
-H 'Content-Type: application/json' \
-H 'access-token: <Cookieから取得してください>' \
-H 'client: <Cookieから取得してください>' \
-H 'uid: <Cookieから取得してください>' \
--data-raw '{"tweet":"ツイート内容"}'
```

## その他

* なし