### PR TITLE
[fix] ローカル環境でのツイート画像のURLにlocalhost:3100をつけたい

### DIFF
--- a/app/controllers/api/v1/tweets_controller.rb
+++ b/app/controllers/api/v1/tweets_controller.rb
@@ -9,6 +9,7 @@ module Api
       def index
         offset = params[:offset].presence || 1
         limit = params[:limit].presence || 10
+        # TODO: ページネーションのために全件検索しているが、パフォーマンス改善のため、全件検索しないようにする
         all_tweets = Tweet.with_attached_image.order(created_at: :desc, id: :desc)
 
         @tweets_paginated = all_tweets.page(offset).per(limit)

--- a/app/views/api/v1/tweets/index.json.jbuilder
+++ b/app/views/api/v1/tweets/index.json.jbuilder
@@ -7,7 +7,7 @@ tweets = @tweets_paginated.map do |tweet|
     created_at: tweet.created_at,
     updated_at: tweet.updated_at
   }
-  hash[:image_url] = tweet.image.attached? ? url_for(tweet.image) : nil
+  hash[:image_url] = tweet.image.attached? ? Rails.application.routes.url_helpers.url_for(tweet.image) : nil
 
   hash
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -2,6 +2,8 @@
 
 require 'active_support/core_ext/integer/time'
 
+Rails.application.routes.default_url_options = { host: 'localhost', port: 3100 }
+
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
@@ -62,6 +64,9 @@ Rails.application.configure do
 
   # Highlight code that triggered database queries in logs.
   config.active_record.verbose_query_logs = true
+
+  # デフォルトのホストURLを設定する
+  default_url_options[:host] = "localhost:3100"
 
   # Raises error for missing translations.
   # config.i18n.raise_on_missing_translations = true


### PR DESCRIPTION
## 課題のリンク

* なし

## やったこと

* default_url_optionsで指定しました
* jbuilder内で使用しているurl_forをRails.application.routes.url_helpersから呼ぶように変更しました

## 動作確認方法

* フロント側で動作確認するので特になし

## その他

* レビュワーへの参考情報（実装上の懸念点や注意点、困りごとなど）
