### PR TITLE
ツイート詳細取得APIを追加

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -31,3 +31,5 @@ RSpec/ExampleLength:
 RSpec/AnyInstance:
   Exclude:
     - "spec/**/*"
+RSpec/LetSetup:
+  Enabled: false

--- a/app/controllers/api/v1/tweets_controller.rb
+++ b/app/controllers/api/v1/tweets_controller.rb
@@ -25,6 +25,10 @@ module Api
         end
       end
 
+      def show
+        @tweet = Tweet.find(params[:id])
+      end
+
       private
 
       def tweet_params

--- a/app/controllers/api/v1/tweets_controller.rb
+++ b/app/controllers/api/v1/tweets_controller.rb
@@ -4,7 +4,7 @@ module Api
   module V1
     class TweetsController < ApplicationController
       include Pagination
-      before_action :authenticate_api_v1_user!, only: %i[index create]
+      before_action :authenticate_api_v1_user!, only: %i[index create show]
 
       def index
         offset = params[:offset].presence || 1

--- a/app/views/api/v1/tweets/index.json.jbuilder
+++ b/app/views/api/v1/tweets/index.json.jbuilder
@@ -10,7 +10,7 @@ tweets = @tweets_paginated.map do |tweet|
   hash[:user] = {
     id: tweet.user.id,
     name: tweet.user.name,
-    nickname: tweet.user.nickname,
+    nickname: tweet.user.nickname
   }
   hash[:image_url] = tweet.image.attached? ? Rails.application.routes.url_helpers.url_for(tweet.image) : nil
 

--- a/app/views/api/v1/tweets/show.json.jbuilder
+++ b/app/views/api/v1/tweets/show.json.jbuilder
@@ -1,0 +1,7 @@
+user = { id: @tweet.user.id, name: @tweet.user.name, nickname: @tweet.user.nickname }
+
+json.tweet  @tweet.tweet
+json.image_url @tweet.image.attached? ? Rails.application.routes.url_helpers.url_for(@tweet.image) : nil
+json.created_at @tweet.created_at
+json.updated_at @tweet.updated_at
+json.user user

--- a/app/views/api/v1/tweets/show.json.jbuilder
+++ b/app/views/api/v1/tweets/show.json.jbuilder
@@ -1,5 +1,6 @@
 user = { id: @tweet.user.id, name: @tweet.user.name, nickname: @tweet.user.nickname }
 
+json.id @tweet.id
 json.tweet  @tweet.tweet
 json.image_url @tweet.image.attached? ? Rails.application.routes.url_helpers.url_for(@tweet.image) : nil
 json.created_at @tweet.created_at

--- a/app/views/api/v1/tweets/show.json.jbuilder
+++ b/app/views/api/v1/tweets/show.json.jbuilder
@@ -1,7 +1,9 @@
+# frozen_string_literal: true
+
 user = { id: @tweet.user.id, name: @tweet.user.name, nickname: @tweet.user.nickname }
 
 json.id @tweet.id
-json.tweet  @tweet.tweet
+json.tweet @tweet.tweet
 json.image_url @tweet.image.attached? ? Rails.application.routes.url_helpers.url_for(@tweet.image) : nil
 json.created_at @tweet.created_at
 json.updated_at @tweet.updated_at

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -66,7 +66,7 @@ Rails.application.configure do
   config.active_record.verbose_query_logs = true
 
   # デフォルトのホストURLを設定する
-  default_url_options[:host] = "localhost:3100"
+  default_url_options[:host] = 'localhost:3100'
 
   # Raises error for missing translations.
   # config.i18n.raise_on_missing_translations = true

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -103,7 +103,7 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
-  
+
   # デフォルトのホストURLを設定する
   default_url_options[:host] = 'twitter-rails-api1-a77730c5e74f.herokuapp.com'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,7 @@ Rails.application.routes.draw do
         resources :sessions, only: [:index]
       end
 
-      resources :tweets, only: %i[index create], format: 'json'
+      resources :tweets, only: %i[index create show], format: 'json'
       resources :images, only: [:create], format: 'json'
     end
   end

--- a/spec/requests/api/v1/tweets_spec.rb
+++ b/spec/requests/api/v1/tweets_spec.rb
@@ -48,4 +48,18 @@ RSpec.describe 'Api::V1::Tweets', type: :request do
       expect(response).to have_http_status(:created)
     end
   end
+
+  describe 'GET /api/v1/tweets/:tweet_id' do
+    let!(:tweet) { FactoryBot.create(:tweet, tweet: 'テストツイート') }
+
+    let!(:tweet_id) do
+      tweet.id
+    end
+      
+    it 'ツイート詳細が取得できること' do
+      subject
+      res = JSON.parse(response.body)
+      expect(res['tweet']).to eq 'テストツイート'
+    end
+  end
 end

--- a/spec/requests/api/v1/tweets_spec.rb
+++ b/spec/requests/api/v1/tweets_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe 'Api::V1::Tweets', type: :request do
     let!(:tweet_id) do
       tweet.id
     end
-      
+
     it 'ツイート詳細が取得できること' do
       subject
       res = JSON.parse(response.body)


### PR DESCRIPTION
## 課題のリンク

* https://github.com/happiness-chain/practice/blob/main/14.2_react/003_%E8%AA%B2%E9%A1%8C.md#%E3%83%84%E3%82%A4%E3%83%BC%E3%83%88%E8%A9%B3%E7%B4%B0

## やったこと

* ツイート詳細取得APIの追加

## やらなかったこと

* ツイートに紐づくコメント取得は別のAPIでやります

## 動作確認方法

* heroku環境だと認証情報やツイートIDが必要だったりするのでフロントエンドのPRができてからで良さそう
* ローカルで確認するなら以下の変更をした後に` curl 'http://localhost:3100/api/v1/tweets/<ツイートID>' | jq .`を叩く
```diff
diff --git a/app/controllers/api/v1/tweets_controller.rb b/app/controllers/api/v1/tweets_controller.rb
index af8a680..efedb59 100644
--- a/app/controllers/api/v1/tweets_controller.rb
+++ b/app/controllers/api/v1/tweets_controller.rb
@@ -4,7 +4,7 @@ module Api
   module V1
     class TweetsController < ApplicationController
       include Pagination
-      before_action :authenticate_api_v1_user!, only: %i[index create show]
+      before_action :authenticate_api_v1_user!, only: %i[index create]
```

## キャプチャ

* ローカル環境で叩くとこんな感じ
```
> curl 'http://localhost:3100/api/v1/tweets/545' | jq .                                                                                          
{
  "id": 545,
  "tweet": "123",
  "image_url": "http://localhost:3100/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBKUT09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--18d5ad3e5a552c102c5290e8746be8b10cdc54e4/rt.png",
  "created_at": "2023-09-17T14:38:18.350Z",
  "updated_at": "2023-09-17T14:38:18.387Z",
  "user": {
    "id": 251,
    "name": "UserName0",
    "nickname": "UserNickname0"
  }
}
```

## その他

* なし
