### PR TITLE
アバター画像更新APIとヘッダー画像更新APIを追加

### DIFF
--- a/app/controllers/api/v1/images_controller.rb
+++ b/app/controllers/api/v1/images_controller.rb
@@ -18,6 +18,28 @@ module Api
           render json: { errors: ['画像のアップロードに失敗しました'] }, status: :unprocessable_entity
         end
       end
+
+      def update_avatar_image
+        user = current_api_v1_user
+
+        user.avatar_image.attach(params[:image])
+        if user.avatar_image.attached?
+          render json: { message: '更新に成功しました' }, status: :ok
+        else
+          render json: { errors: ['画像の更新に失敗しました'] }, status: :unprocessable_entity
+        end
+      end
+
+      def update_header_image
+        user = current_api_v1_user
+
+        user.header_image.attach(params[:image])
+        if user.header_image.attached?
+          render json: { message: '更新に成功しました' }, status: :ok
+        else
+          render json: { errors: ['画像の更新に失敗しました'] }, status: :unprocessable_entity
+        end
+      end
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,10 @@ Rails.application.routes.draw do
       end
 
       resources :users, only: %i[show], format: 'json'
-      resource :profile, only: %i[update], controller: 'users', format: 'json'
+      resource :profile, only: %i[update], controller: 'users', format: 'json' do
+        put :avatar_image, controller: 'images', action: 'update_avatar_image', format: 'json'
+        put :header_image, controller: 'images', action: 'update_header_image', format: 'json'
+      end
       resources :tweets, only: %i[index create show], format: 'json'
       resources :images, only: [:create], format: 'json'
     end


### PR DESCRIPTION
## 課題のリンク

* https://github.com/happiness-chain/practice/blob/main/14.2_react/003_%E8%AA%B2%E9%A1%8C.md#%E3%83%97%E3%83%AD%E3%83%95%E3%82%A3%E3%83%BC%E3%83%AB%E7%94%BB%E9%9D%A2%E5%AE%9F%E8%A3%85

## やったこと

* アバター画像更新API `PUT /api/v1/profile/avatar_image` の追加
* ヘッダー画像更新API `PUT /api/v1/profile/header_image` の追加

## 動作確認方法

* 動作確認はフロント実装後で良さそう
* Postmanで確認するなら
  * `https://twitter-rails-api1-a77730c5e74f.herokuapp.com/api/v1/profile/avatar_image`
  * <img width="400" alt="image" src="https://github.com/8tako8tako8/twitter_rails_api/assets/65395999/8f354ade-15da-4683-9092-81be0cb0e268">
  * <img width="400" alt="image" src="https://github.com/8tako8tako8/twitter_rails_api/assets/65395999/1e673601-82b2-4b49-88f9-00b91592e962">

## その他

* なし