### PR TITLE
[fix] アバター画像、ヘッダー画像の更新時のレスポンスに画像URLを追加

### DIFF
--- a/app/controllers/api/v1/images_controller.rb
+++ b/app/controllers/api/v1/images_controller.rb
@@ -24,7 +24,7 @@ module Api
 
         user.avatar_image.attach(params[:image])
         if user.avatar_image.attached?
-          render json: { message: '更新に成功しました' }, status: :ok
+          render json: { avatar_image_url: url_for(user.avatar_image) }, status: :ok
         else
           render json: { errors: ['画像の更新に失敗しました'] }, status: :unprocessable_entity
         end
@@ -35,7 +35,7 @@ module Api
 
         user.header_image.attach(params[:image])
         if user.header_image.attached?
-          render json: { message: '更新に成功しました' }, status: :ok
+          render json: { header_image_url: url_for(user.header_image) }, status: :ok
         else
           render json: { errors: ['画像の更新に失敗しました'] }, status: :unprocessable_entity
         end


### PR DESCRIPTION
## 課題のリンク

*  なし

## やったこと

*  フロント側で画像URLを更新したいので、アバター画像・ヘッダー画像の更新時のレスポンスに画像URLを追加した

## 動作確認方法

* フロント側で見るので大丈夫

## その他

* レビュワーへの参考情報（実装上の懸念点や注意点、困りごとなど）
