### PR TITLE
ツイート削除APIを追加

### DIFF
--- a/app/controllers/api/v1/tweets_controller.rb
+++ b/app/controllers/api/v1/tweets_controller.rb
@@ -33,9 +33,9 @@ module Api
         tweet_id = params[:id]
         tweet = Tweet.find(tweet_id)
 
-        # if tweet.user.id != current_api_v1_user.id
-        #   render json: { errors: 'ツイートした本人でないためツイートを削除できません' }, status: :unauthorized
-        # end
+        if tweet.user.id != current_api_v1_user.id
+          render json: { errors: 'ツイートした本人でないためツイートを削除できません' }, status: :unauthorized
+        end
 
         if tweet.destroy
           render json: { tweet: }, status: :ok

--- a/app/controllers/api/v1/tweets_controller.rb
+++ b/app/controllers/api/v1/tweets_controller.rb
@@ -4,7 +4,7 @@ module Api
   module V1
     class TweetsController < ApplicationController
       include Pagination
-      before_action :authenticate_api_v1_user!, only: %i[index create show]
+      before_action :authenticate_api_v1_user!, only: %i[index create show destroy]
 
       def index
         offset = params[:offset].presence || 1
@@ -27,6 +27,21 @@ module Api
 
       def show
         @tweet = Tweet.find(params[:id])
+      end
+
+      def destroy
+        tweet_id = params[:id]
+        tweet = Tweet.find(tweet_id)
+
+        # if tweet.user.id != current_api_v1_user.id
+        #   render json: { errors: 'ツイートした本人でないためツイートを削除できません' }, status: :unauthorized
+        # end
+
+        if tweet.destroy
+          render json: { tweet: }, status: :ok
+        else
+          render json: { errors: tweet.errors }, status: :unprocessable_entity
+        end
       end
 
       private

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,7 +17,7 @@ Rails.application.routes.draw do
         put :avatar_image, controller: 'images', action: 'update_avatar_image', format: 'json'
         put :header_image, controller: 'images', action: 'update_header_image', format: 'json'
       end
-      resources :tweets, only: %i[index create show], format: 'json'
+      resources :tweets, only: %i[index create show destroy], format: 'json'
       resources :images, only: [:create], format: 'json'
     end
   end


### PR DESCRIPTION
## 課題のリンク

* https://github.com/happiness-chain/practice/blob/main/14.2_react/003_%E8%AA%B2%E9%A1%8C.md#%E3%83%84%E3%82%A4%E3%83%BC%E3%83%88%E5%89%8A%E9%99%A4%E6%A9%9F%E8%83%BD

## やったこと

* ツイート削除APIを追加しました

## やらなかったこと

* なし

## 動作確認方法

* 動作確認はフロント実装後でも良さそう
* ローカルで確認した
  * ツイートに紐づいたimageの削除も成功しているので大丈夫そう
  * ```
curl -X DELETE 'http://localhost:3100/api/v1/tweets/550' | jq .
```
  * <img width="700" alt="アプリケーションログ" src="https://github.com/8tako8tako8/twitter_rails_api/assets/65395999/9ddd4db6-0834-4091-bc87-6b5766120f13">

## その他

* なし