### PR TITLE
[fix] セッション情報取得APIのレスポンスに必要なデータを調整

### DIFF
--- a/app/controllers/api/v1/auth/sessions_controller.rb
+++ b/app/controllers/api/v1/auth/sessions_controller.rb
@@ -5,7 +5,7 @@ module Api
     module Auth
       class SessionsController < ApplicationController
         def index
-          render json: current_api_v1_user
+          @user = current_api_v1_user
         end
       end
     end

--- a/app/views/api/v1/auth/sessions/index.json.jbuilder
+++ b/app/views/api/v1/auth/sessions/index.json.jbuilder
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+json.extract! @user, :id, :email, :name, :nickname
+json.avatar_image_url @user.avatar_image.attached? ? Rails.application.routes.url_helpers.url_for(@user.avatar_image) : nil

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
         registrations: 'api/v1/auth/registrations'
       }
       namespace :auth do
-        resources :sessions, only: [:index]
+        resources :sessions, only: [:index], format: 'json'
       end
 
       resources :users, only: %i[show], format: 'json'


### PR DESCRIPTION
## 課題のリンク

* なし

## やったこと

* セッション情報取得APIにアバター画像が足りていなかったり、フロント側で必要でないデータが含まれているので調整した

## 動作確認方法

* なし

## その他

* なし