### PR TITLE
リツイートAPI・リツイートキャンセルAPI・リツイート数を追加

### DIFF
--- a/app/controllers/api/v1/retweets_controller.rb
+++ b/app/controllers/api/v1/retweets_controller.rb
@@ -14,6 +14,17 @@ module Api
         current_api_v1_user.retweet(tweet)
         render json: { tweet: }, status: :created
       end
+
+      def destroy
+        tweet = Tweet.find_by(id: params[:tweet_id])
+        unless tweet
+          render json: { errors: 'ツイートが見つかりません' }, status: :not_found
+          return
+        end
+
+        current_api_v1_user.cancel_retweet(tweet)
+        render json: { tweet: }, status: :ok
+      end
     end
   end
 end

--- a/app/controllers/api/v1/retweets_controller.rb
+++ b/app/controllers/api/v1/retweets_controller.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class RetweetsController < ApplicationController
+
+      def create
+        tweet = Tweet.find_by(id: params[:tweet_id])
+        unless tweet
+          render json: { errors: 'ツイートが見つかりません' }, status: :not_found
+          return
+        end
+
+        current_api_v1_user.retweet(tweet)
+        render json: { tweet: }, status: :created
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/retweets_controller.rb
+++ b/app/controllers/api/v1/retweets_controller.rb
@@ -3,6 +3,7 @@
 module Api
   module V1
     class RetweetsController < ApplicationController
+      before_action :authenticate_api_v1_user!, only: %i[create destroy]
 
       def create
         tweet = Tweet.find_by(id: params[:tweet_id])

--- a/app/controllers/api/v1/retweets_controller.rb
+++ b/app/controllers/api/v1/retweets_controller.rb
@@ -13,7 +13,7 @@ module Api
         end
 
         current_api_v1_user.retweet(tweet)
-        render json: { tweet: }, status: :created
+        render json: { tweet: }, status: :ok
       end
 
       def destroy

--- a/app/models/retweet.rb
+++ b/app/models/retweet.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class Retweet < ApplicationRecord
+  belongs_to :user
+  belongs_to :tweet
+
+  validates :tweet, presence: true, uniqueness: { scope: :user }
+end

--- a/app/models/tweet.rb
+++ b/app/models/tweet.rb
@@ -11,4 +11,8 @@ class Tweet < ApplicationRecord
   def created_by?(user)
     self.user.id == user.id
   end
+
+  def count_retweets
+    retweets.count
+  end
 end

--- a/app/models/tweet.rb
+++ b/app/models/tweet.rb
@@ -4,6 +4,7 @@ class Tweet < ApplicationRecord
   belongs_to :user
   has_one_attached :image
   has_many :comments, dependent: :destroy
+  has_many :retweets, dependent: :destroy
 
   validates :tweet, presence: true, length: { maximum: 200 }
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -26,4 +26,7 @@ class User < ApplicationRecord
     retweets.find_or_create_by(tweet:)
   end
 
+  def cancel_retweet(tweet)
+    retweets.find_by(tweet:)&.destroy
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -21,4 +21,9 @@ class User < ApplicationRecord
   def comment(comment, tweet)
     comments.create(comment:, tweet:)
   end
+
+  def retweet(tweet)
+    retweets.find_or_create_by(tweet:)
+  end
+
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,6 +7,7 @@ class User < ApplicationRecord
 
   has_many :tweets, dependent: :destroy
   has_many :comments, dependent: :destroy
+  has_many :retweets, dependent: :destroy
   has_one_attached :avatar_image
   has_one_attached :header_image
 

--- a/app/views/api/v1/tweets/index.json.jbuilder
+++ b/app/views/api/v1/tweets/index.json.jbuilder
@@ -14,6 +14,8 @@ tweets = @tweets_paginated.map do |tweet|
   }
   hash[:image_url] = tweet.image.attached? ? Rails.application.routes.url_helpers.url_for(tweet.image) : nil
 
+  hash[:retweets] = tweet.count_retweets
+
   hash
 end
 

--- a/app/views/api/v1/tweets/show.json.jbuilder
+++ b/app/views/api/v1/tweets/show.json.jbuilder
@@ -8,3 +8,4 @@ json.image_url @tweet.image.attached? ? Rails.application.routes.url_helpers.url
 json.created_at @tweet.created_at
 json.updated_at @tweet.updated_at
 json.user user
+json.retweets @tweet.count_retweets

--- a/app/views/api/v1/users/show.json.jbuilder
+++ b/app/views/api/v1/users/show.json.jbuilder
@@ -5,7 +5,8 @@ tweets = @tweets.map do |tweet|
     id: tweet.id,
     tweet: tweet.tweet,
     created_at: tweet.created_at,
-    updated_at: tweet.updated_at
+    updated_at: tweet.updated_at,
+    retweets: tweet.count_retweets
   }
 
   avatar_image_url = tweet.user.avatar_image.attached? ? Rails.application.routes.url_helpers.url_for(tweet.user.avatar_image) : nil

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,7 @@ Rails.application.routes.draw do
       resources :tweets, only: %i[index create destroy], format: 'json'
       resources :tweets, only: [:show], format: 'json' do
         resources :comments, only: [:index]
+        resource :retweet, only: %i[create]
       end
       resources :images, only: [:create], format: 'json'
       resources :comments, only: %i[create destroy], format: 'json'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,7 +20,7 @@ Rails.application.routes.draw do
       resources :tweets, only: %i[index create destroy], format: 'json'
       resources :tweets, only: [:show], format: 'json' do
         resources :comments, only: [:index]
-        resource :retweet, only: %i[create]
+        resource :retweet, only: %i[create destroy]
       end
       resources :images, only: [:create], format: 'json'
       resources :comments, only: %i[create destroy], format: 'json'

--- a/db/migrate/20231014053308_create_retweets.rb
+++ b/db/migrate/20231014053308_create_retweets.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class CreateRetweets < ActiveRecord::Migration[7.0]
+  def change
+    create_table :retweets do |t|
+      t.references :tweet, null: false, foreign_key: true
+      t.references :user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+    add_index :retweets, %i[tweet_id user_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_10_09_131519) do
+ActiveRecord::Schema[7.0].define(version: 2023_10_14_053308) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -50,6 +50,16 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_09_131519) do
     t.datetime "updated_at", null: false
     t.index ["tweet_id"], name: "index_comments_on_tweet_id"
     t.index ["user_id"], name: "index_comments_on_user_id"
+  end
+
+  create_table "retweets", force: :cascade do |t|
+    t.bigint "tweet_id", null: false
+    t.bigint "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["tweet_id", "user_id"], name: "index_retweets_on_tweet_id_and_user_id", unique: true
+    t.index ["tweet_id"], name: "index_retweets_on_tweet_id"
+    t.index ["user_id"], name: "index_retweets_on_user_id"
   end
 
   create_table "tweets", force: :cascade do |t|
@@ -94,5 +104,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_09_131519) do
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "comments", "tweets"
   add_foreign_key "comments", "users"
+  add_foreign_key "retweets", "tweets"
+  add_foreign_key "retweets", "users"
   add_foreign_key "tweets", "users"
 end

--- a/spec/factories/retweets.rb
+++ b/spec/factories/retweets.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :retweet do
+    association :user
+    association :tweet
+  end
+end

--- a/spec/models/retweet_spec.rb
+++ b/spec/models/retweet_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe Retweet, type: :model do
+  describe 'バリデーション' do
+    let!(:user) { FactoryBot.create(:user) }
+    let!(:tweet) { FactoryBot.create(:tweet) }
+
+    it 'リツイートが正しく作成できること' do
+      retweet = FactoryBot.build(:retweet)
+      expect(retweet).to be_valid
+    end
+
+    it '同一ユーザーが同一ツイートを複数回リツイートできないこと' do
+      FactoryBot.create(:retweet, user: user, tweet: tweet)
+      duplicate_retweet = FactoryBot.build(:retweet, user: user, tweet: tweet)
+      expect(duplicate_retweet).not_to be_valid
+    end
+  end
+end

--- a/spec/models/retweet_spec.rb
+++ b/spec/models/retweet_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Retweet, type: :model do
@@ -11,8 +13,8 @@ RSpec.describe Retweet, type: :model do
     end
 
     it '同一ユーザーが同一ツイートを複数回リツイートできないこと' do
-      FactoryBot.create(:retweet, user: user, tweet: tweet)
-      duplicate_retweet = FactoryBot.build(:retweet, user: user, tweet: tweet)
+      FactoryBot.create(:retweet, user:, tweet:)
+      duplicate_retweet = FactoryBot.build(:retweet, user:, tweet:)
       expect(duplicate_retweet).not_to be_valid
     end
   end

--- a/spec/requests/api/v1/retweets_spec.rb
+++ b/spec/requests/api/v1/retweets_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe 'Api::V1::Retweets', type: :request do

--- a/spec/requests/api/v1/retweets_spec.rb
+++ b/spec/requests/api/v1/retweets_spec.rb
@@ -1,0 +1,59 @@
+require 'rails_helper'
+
+RSpec.describe 'Api::V1::Retweets', type: :request do
+  # 認証をスキップさせる
+  before do
+    allow_any_instance_of(Api::V1::RetweetsController).to receive(:authenticate_api_v1_user!).and_return(true)
+  end
+
+  describe 'POST /api/v1/tweets/:tweet_id/retweet' do
+    subject { post(api_v1_tweet_retweet_path(tweet_id), headers:) }
+
+    let!(:user) { FactoryBot.create(:user) }
+    let!(:tweet) { FactoryBot.create(:tweet) }
+
+    let!(:tweet_id) do
+      tweet.id
+    end
+
+    # 認証情報をヘッダーに付与する
+    before do
+      auth_token = user.create_new_auth_token
+      headers['access-token'] = auth_token['access-token']
+      headers['client'] = auth_token['client']
+      headers['uid'] = auth_token['uid']
+    end
+
+    it 'リツイートできること' do
+      subject
+      expect(response).to have_http_status(:ok)
+      expect(tweet.retweets.reload.length).to eq 1
+    end
+  end
+
+  describe 'DELETE /api/v1/tweets/:tweet_id/retweet' do
+    subject { delete(api_v1_tweet_retweet_path(tweet_id), headers:) }
+
+    let!(:user) { FactoryBot.create(:user) }
+    let!(:tweet) { FactoryBot.create(:tweet) }
+    let!(:retweet) { FactoryBot.create(:retweet, user:, tweet:) }
+
+    let!(:tweet_id) do
+      tweet.id
+    end
+
+    # 認証情報をヘッダーに付与する
+    before do
+      auth_token = user.create_new_auth_token
+      headers['access-token'] = auth_token['access-token']
+      headers['client'] = auth_token['client']
+      headers['uid'] = auth_token['uid']
+    end
+
+    it 'リツイートが削除できること' do
+      subject
+      expect(response).to have_http_status(:ok)
+      expect(tweet.retweets.reload.length).to eq 0
+    end
+  end
+end


### PR DESCRIPTION
## 課題のリンク

* https://github.com/happiness-chain/practice/blob/main/14.2_react/003_%E8%AA%B2%E9%A1%8C.md#%E3%83%AA%E3%83%84%E3%82%A4%E3%83%BC%E3%83%88

## やったこと

* リツイートAPIを追加しました
* リツイートキャンセルAPIを追加しました
* ツイート一覧・ツイート詳細・ユーザー情報APIにリツイート数を追加しました

## 動作確認方法

* 動作確認はフロント実装後でも良さそう
* ローカルで確認するなら

```
curl -X POST 'http://localhost:3100/api/v1/tweets/:tweet_id/retweet' \
-H 'Content-Type: application/json' \
-H 'access-token: <Cookieから取得してください>' \
-H 'client: <Cookieから取得してください>' \
-H 'uid: <Cookieから取得してください>'
```

```
curl -X DELETE 'http://localhost:3100/api/v1/tweets/:tweet_id/retweet' \
-H 'Content-Type: application/json' \
-H 'access-token: <Cookieから取得してください>' \
-H 'client: <Cookieから取得してください>' \
-H 'uid: <Cookieから取得してください>'
```

## その他

* なし
