### PR TITLE
いいねAPI・いいねキャンセルAPI・いいね数を追加 

### DIFF
--- a/app/controllers/api/v1/favorites_contorller.rb
+++ b/app/controllers/api/v1/favorites_contorller.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class FavoritesController < ApplicationController
+      before_action :authenticate_api_v1_user!, only: %i[create destroy]
+
+      def create
+        tweet = Tweet.find_by(id: params[:tweet_id])
+        unless tweet
+          render json: { errors: 'ツイートが見つかりません' }, status: :not_found
+          return
+        end
+
+        current_api_v1_user.favorite(tweet)
+        render json: { tweet: }, status: :ok
+      end
+
+      def destroy
+        tweet = Tweet.find_by(id: params[:tweet_id])
+        unless tweet
+          render json: { errors: 'ツイートが見つかりません' }, status: :not_found
+          return
+        end
+
+        current_api_v1_user.cancel_favorite(tweet)
+        render json: { tweet: }, status: :ok
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/favorites_controller.rb
+++ b/app/controllers/api/v1/favorites_controller.rb
@@ -3,7 +3,7 @@
 module Api
   module V1
     class FavoritesController < ApplicationController
-      before_action :authenticate_api_v1_user!, only: %i[create destroy]
+      # before_action :authenticate_api_v1_user!, only: %i[create destroy]
 
       def create
         tweet = Tweet.find_by(id: params[:tweet_id])

--- a/app/controllers/api/v1/favorites_controller.rb
+++ b/app/controllers/api/v1/favorites_controller.rb
@@ -3,7 +3,7 @@
 module Api
   module V1
     class FavoritesController < ApplicationController
-      # before_action :authenticate_api_v1_user!, only: %i[create destroy]
+      before_action :authenticate_api_v1_user!, only: %i[create destroy]
 
       def create
         tweet = Tweet.find_by(id: params[:tweet_id])

--- a/app/models/favorite.rb
+++ b/app/models/favorite.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class Favorite < ApplicationRecord
+  belongs_to :tweet
+  belongs_to :user
+
+  validates :tweet, presence: true, uniqueness: { scope: :user }
+end

--- a/app/models/tweet.rb
+++ b/app/models/tweet.rb
@@ -5,6 +5,7 @@ class Tweet < ApplicationRecord
   has_one_attached :image
   has_many :comments, dependent: :destroy
   has_many :retweets, dependent: :destroy
+  has_many :favorites, dependent: :destroy
 
   validates :tweet, presence: true, length: { maximum: 200 }
 
@@ -14,5 +15,9 @@ class Tweet < ApplicationRecord
 
   def count_retweets
     retweets.count
+  end
+
+  def count_favorites
+    favorites.count
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,6 +8,7 @@ class User < ApplicationRecord
   has_many :tweets, dependent: :destroy
   has_many :comments, dependent: :destroy
   has_many :retweets, dependent: :destroy
+  has_many :favorites, dependent: :destroy
   has_one_attached :avatar_image
   has_one_attached :header_image
 
@@ -28,5 +29,13 @@ class User < ApplicationRecord
 
   def cancel_retweet(tweet)
     retweets.find_by(tweet:)&.destroy
+  end
+
+  def favorite(tweet)
+    favorites.find_or_create_by(tweet:)
+  end
+
+  def cancel_favorite(tweet)
+    favorites.find_by(tweet:)&.destroy
   end
 end

--- a/app/views/api/v1/tweets/index.json.jbuilder
+++ b/app/views/api/v1/tweets/index.json.jbuilder
@@ -20,6 +20,8 @@ tweets = @tweets_paginated.map do |tweet|
 
   hash[:retweets] = tweet.count_retweets
 
+  hash[:favorites] = tweet.count_favorites
+
   hash
 end
 

--- a/app/views/api/v1/tweets/show.json.jbuilder
+++ b/app/views/api/v1/tweets/show.json.jbuilder
@@ -15,3 +15,4 @@ json.created_at @tweet.created_at
 json.updated_at @tweet.updated_at
 json.user user
 json.retweets @tweet.count_retweets
+json.favorites @tweet.count_favorites

--- a/app/views/api/v1/users/show.json.jbuilder
+++ b/app/views/api/v1/users/show.json.jbuilder
@@ -7,6 +7,7 @@ tweets = @tweets.map do |tweet|
     created_at: tweet.created_at,
     updated_at: tweet.updated_at,
     retweets: tweet.count_retweets
+    favorites: tweet.count_favorites
   }
 
   avatar_image_url = tweet.user.avatar_image.attached? ? Rails.application.routes.url_helpers.url_for(tweet.user.avatar_image) : nil

--- a/app/views/api/v1/users/show.json.jbuilder
+++ b/app/views/api/v1/users/show.json.jbuilder
@@ -6,7 +6,7 @@ tweets = @tweets.map do |tweet|
     tweet: tweet.tweet,
     created_at: tweet.created_at,
     updated_at: tweet.updated_at,
-    retweets: tweet.count_retweets
+    retweets: tweet.count_retweets,
     favorites: tweet.count_favorites
   }
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,7 @@ Rails.application.routes.draw do
       resources :tweets, only: [:show], format: 'json' do
         resources :comments, only: [:index]
         resource :retweet, only: %i[create destroy]
+        resource :favorite, only: %i[create destroy]
       end
       resources :images, only: [:create], format: 'json'
       resources :comments, only: %i[create destroy], format: 'json'

--- a/db/migrate/20231016042434_create_favorites.rb
+++ b/db/migrate/20231016042434_create_favorites.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class CreateFavorites < ActiveRecord::Migration[7.0]
+  def change
+    create_table :favorites do |t|
+      t.references :tweet, null: false, foreign_key: true
+      t.references :user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+    add_index :favorites, %i[tweet_id user_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_10_14_053308) do
+ActiveRecord::Schema[7.0].define(version: 2023_10_16_042434) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -50,6 +50,16 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_14_053308) do
     t.datetime "updated_at", null: false
     t.index ["tweet_id"], name: "index_comments_on_tweet_id"
     t.index ["user_id"], name: "index_comments_on_user_id"
+  end
+
+  create_table "favorites", force: :cascade do |t|
+    t.bigint "tweet_id", null: false
+    t.bigint "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["tweet_id", "user_id"], name: "index_favorites_on_tweet_id_and_user_id", unique: true
+    t.index ["tweet_id"], name: "index_favorites_on_tweet_id"
+    t.index ["user_id"], name: "index_favorites_on_user_id"
   end
 
   create_table "retweets", force: :cascade do |t|
@@ -104,6 +114,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_14_053308) do
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "comments", "tweets"
   add_foreign_key "comments", "users"
+  add_foreign_key "favorites", "tweets"
+  add_foreign_key "favorites", "users"
   add_foreign_key "retweets", "tweets"
   add_foreign_key "retweets", "users"
   add_foreign_key "tweets", "users"

--- a/spec/factories/favorites.rb
+++ b/spec/factories/favorites.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :favorite do
+    association :user
+    association :tweet
+  end
+end

--- a/spec/models/favorite_spec.rb
+++ b/spec/models/favorite_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Favorite, type: :model do
+  describe 'バリデーション' do
+    let!(:user) { FactoryBot.create(:user) }
+    let!(:tweet) { FactoryBot.create(:tweet) }
+
+    it 'いいねが正しく作成できること' do
+      favorite = FactoryBot.build(:favorite)
+      expect(favorite).to be_valid
+    end
+
+    it '同一ユーザーが同一ツイートを複数回いいねできないこと' do
+      FactoryBot.create(:favorite, user:, tweet:)
+      duplicate_favorite = FactoryBot.build(:favorite, user:, tweet:)
+      expect(duplicate_favorite).not_to be_valid
+    end
+  end
+end

--- a/spec/requests/api/v1/favorites_spec.rb
+++ b/spec/requests/api/v1/favorites_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Api::V1::favorites', type: :request do
+  # 認証をスキップさせる
+  before do
+    allow_any_instance_of(Api::V1::FavoritesController).to receive(:authenticate_api_v1_user!).and_return(true)
+  end
+
+  describe 'POST /api/v1/tweets/:tweet_id/favorite' do
+    subject { post(api_v1_tweet_favorite_path(tweet_id), headers:) }
+
+    let!(:user) { FactoryBot.create(:user) }
+    let!(:tweet) { FactoryBot.create(:tweet) }
+
+    let!(:tweet_id) do
+      tweet.id
+    end
+
+    # 認証情報をヘッダーに付与する
+    before do
+      auth_token = user.create_new_auth_token
+      headers['access-token'] = auth_token['access-token']
+      headers['client'] = auth_token['client']
+      headers['uid'] = auth_token['uid']
+    end
+
+    it 'いいねできること' do
+      subject
+      expect(response).to have_http_status(:ok)
+      expect(tweet.favorites.reload.length).to eq 1
+    end
+  end
+
+  describe 'DELETE /api/v1/tweets/:tweet_id/favorite' do
+    subject { delete(api_v1_tweet_favorite_path(tweet_id), headers:) }
+
+    let!(:user) { FactoryBot.create(:user) }
+    let!(:tweet) { FactoryBot.create(:tweet) }
+    let!(:favorite) { FactoryBot.create(:favorite, user:, tweet:) }
+
+    let!(:tweet_id) do
+      tweet.id
+    end
+
+    # 認証情報をヘッダーに付与する
+    before do
+      auth_token = user.create_new_auth_token
+      headers['access-token'] = auth_token['access-token']
+      headers['client'] = auth_token['client']
+      headers['uid'] = auth_token['uid']
+    end
+
+    it 'いいねが削除できること' do
+      subject
+      expect(response).to have_http_status(:ok)
+      expect(tweet.favorites.reload.length).to eq 0
+    end
+  end
+end


### PR DESCRIPTION
## 課題のリンク

* https://github.com/happiness-chain/practice/blob/main/14.2_react/003_%E8%AA%B2%E9%A1%8C.md#%E3%81%84%E3%81%84%E3%81%AD

## やったこと

* いいねAPIを追加しました
* いいねキャンセルAPIを追加しました
* ツイート一覧・ツイート詳細・ユーザー情報APIにいいね数を追加しました

## 動作確認方法

* 動作確認はフロント実装後でも良さそう
* ローカルで確認するなら

```
curl -X POST 'http://localhost:3100/api/v1/tweets/:tweet_id/favorite' \
-H 'Content-Type: application/json' \
-H 'access-token: <Cookieから取得してください>' \
-H 'client: <Cookieから取得してください>' \
-H 'uid: <Cookieから取得してください>'
```

```
curl -X DELETE 'http://localhost:3100/api/v1/tweets/:tweet_id/favorite' \
-H 'Content-Type: application/json' \
-H 'access-token: <Cookieから取得してください>' \
-H 'client: <Cookieから取得してください>' \
-H 'uid: <Cookieから取得してください>'
```

## その他

* なし
