### PR TITLE
フォローAPI ・フォロー解除APIを追加

### DIFF
--- a/app/controllers/api/v1/follows_controller.rb
+++ b/app/controllers/api/v1/follows_controller.rb
@@ -19,7 +19,7 @@ module Api
         end
 
         if current_api_v1_user.follow(user)
-          render json: { }, status: :no_content
+          render json: {}, status: :no_content
         else
           render json: { errors: 'フォローに失敗しました' }, status: :internal_server_error
         end
@@ -39,7 +39,7 @@ module Api
         end
 
         if current_api_v1_user.cancel_follow(user)
-          render json: { }, status: :no_content
+          render json: {}, status: :no_content
         else
           render json: { errors: 'フォロー解除に失敗しました' }, status: :internal_server_error
         end

--- a/app/controllers/api/v1/follows_controller.rb
+++ b/app/controllers/api/v1/follows_controller.rb
@@ -13,7 +13,7 @@ module Api
           return
         end
 
-        if current_api_v1_user.is_same?(user)
+        if current_api_v1_user.same?(user)
           render json: { errors: '自分自身をフォローすることはできません' }, status: :bad_request
           return
         end
@@ -33,7 +33,7 @@ module Api
           return
         end
 
-        if current_api_v1_user.is_same?(user)
+        if current_api_v1_user.same?(user)
           render json: { errors: '自分自身をフォローすることはできません' }, status: :bad_request
           return
         end

--- a/app/controllers/api/v1/follows_controller.rb
+++ b/app/controllers/api/v1/follows_controller.rb
@@ -39,9 +39,9 @@ module Api
         end
 
         if current_api_v1_user.cancel_follow(user)
-          render status: :no_content
+          render json: { }, status: :no_content
         else
-          render json: { errors: 'フォローに失敗しました' }, status: :internal_server_error
+          render json: { errors: 'フォロー解除に失敗しました' }, status: :internal_server_error
         end
       end
     end

--- a/app/controllers/api/v1/follows_controller.rb
+++ b/app/controllers/api/v1/follows_controller.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class FollowsController < ApplicationController
+      before_action :authenticate_api_v1_user!, only: %i[create destroy]
+
+      def create
+        user = User.find(params[:user_id])
+
+        unless user
+          render json: { errors: 'ユーザーが見つかりません' }, status: :not_found
+          return
+        end
+
+        if user == current_api_v1_user
+          render json: { errors: '自分自身をフォローすることはできません' }, status: :bad_request
+          return
+        end
+
+        if current_api_v1_user.follow(user)
+          render json: { }, status: :no_content
+        else
+          render json: { errors: 'フォローに失敗しました' }, status: :internal_server_error
+        end
+      end
+
+      def destroy
+        user = User.find(params[:user_id])
+
+        unless user
+          render json: { errors: 'ユーザーが見つかりません' }, status: :not_found
+          return
+        end
+
+        if user == current_api_v1_user
+          render json: { errors: '自分自身をフォローすることはできません' }, status: :bad_request
+          return
+        end
+
+        if current_api_v1_user.cancel_follow(user)
+          render status: :no_content
+        else
+          render json: { errors: 'フォローに失敗しました' }, status: :internal_server_error
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/follows_controller.rb
+++ b/app/controllers/api/v1/follows_controller.rb
@@ -13,7 +13,7 @@ module Api
           return
         end
 
-        if user == current_api_v1_user
+        if current_api_v1_user.is_same?(user)
           render json: { errors: '自分自身をフォローすることはできません' }, status: :bad_request
           return
         end
@@ -33,7 +33,7 @@ module Api
           return
         end
 
-        if user == current_api_v1_user
+        if current_api_v1_user.is_same?(user)
           render json: { errors: '自分自身をフォローすることはできません' }, status: :bad_request
           return
         end

--- a/app/models/follow.rb
+++ b/app/models/follow.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class Follow < ApplicationRecord
+  belongs_to :follower_user, class_name: 'User'
+  belongs_to :followed_user, class_name: 'User'
+
+  validates :follower_user_id, presence: true
+  validates :followed_user_id, presence: true, uniqueness: { scope: :follower_user_id }
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -23,6 +23,10 @@ class User < ApplicationRecord
   # TODO: サインイン時にallow_blankが適応されずバリデーションエラーとなるので一旦コメントアウト
   # validates :website_url, format: /\A#{URI::DEFAULT_PARSER.make_regexp(%w[http https])}\z/, allow_blank: true
 
+  def is_same?(user)
+    id == user.id
+  end
+
   def comment(comment, tweet)
     comments.create(comment:, tweet:)
   end
@@ -52,13 +56,13 @@ class User < ApplicationRecord
   end
 
   def follow(user)
-    return unless id != user.id
+    return if is_same?(user)
 
     active_relationships.find_or_create_by(followed_user_id: user.id)
   end
 
   def cancel_follow(user)
-    return unless id != user.id
+    return if is_same?(user)
 
     ar = active_relationships.find_by(followed_user_id: user.id)
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -60,6 +60,14 @@ class User < ApplicationRecord
   def cancel_follow(user)
     return unless id != user.id
 
-    active_relationships.find_by(followed_user_id: user.id)&.destroy
+    ar = active_relationships.find_by(followed_user_id: user.id)
+
+    # 
+    # NOTE:
+    #   active_relationships が見つからない場合、フォロー解除済みとしてtrueを返す
+    # 
+    return true unless ar
+    
+    ar.destroy
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -62,12 +62,12 @@ class User < ApplicationRecord
 
     ar = active_relationships.find_by(followed_user_id: user.id)
 
-    # 
+    #
     # NOTE:
     #   active_relationships が見つからない場合、フォロー解除済みとしてtrueを返す
-    # 
+    #
     return true unless ar
-    
+
     ar.destroy
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,6 +9,10 @@ class User < ApplicationRecord
   has_many :comments, dependent: :destroy
   has_many :retweets, dependent: :destroy
   has_many :favorites, dependent: :destroy
+  has_many :active_relationships, class_name: 'Follow', foreign_key: 'follower_user_id', dependent: :destroy, inverse_of: :follower_user
+  has_many :followings, through: :active_relationships, source: :followed_user
+  has_many :passive_relationships, class_name: 'Follow', foreign_key: 'followed_user_id', dependent: :destroy, inverse_of: :followed_user
+  has_many :followers, through: :passive_relationships, source: :follower_user
   has_one_attached :avatar_image
   has_one_attached :header_image
 
@@ -45,5 +49,17 @@ class User < ApplicationRecord
 
   def favorite?(tweet)
     favorites.exists?(tweet:)
+  end
+
+  def follow(user)
+    return unless id != user.id
+
+    active_relationships.find_or_create_by(followed_user_id: user.id)
+  end
+
+  def cancel_follow(user)
+    return unless id != user.id
+
+    active_relationships.find_by(followed_user_id: user.id)&.destroy
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -23,7 +23,7 @@ class User < ApplicationRecord
   # TODO: サインイン時にallow_blankが適応されずバリデーションエラーとなるので一旦コメントアウト
   # validates :website_url, format: /\A#{URI::DEFAULT_PARSER.make_regexp(%w[http https])}\z/, allow_blank: true
 
-  def is_same?(user)
+  def same?(user)
     id == user.id
   end
 
@@ -56,13 +56,13 @@ class User < ApplicationRecord
   end
 
   def follow(user)
-    return if is_same?(user)
+    return if same?(user)
 
     active_relationships.find_or_create_by(followed_user_id: user.id)
   end
 
   def cancel_follow(user)
-    return if is_same?(user)
+    return if same?(user)
 
     ar = active_relationships.find_by(followed_user_id: user.id)
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,8 @@ Rails.application.routes.draw do
       end
 
       resources :users, only: %i[show], format: 'json' do
-        resource :follow, only: %i[create destroy]
+        post :follow, to: 'follows#create'
+        post :unfollow, to: 'follows#destroy'
       end
       resource :profile, only: %i[update], controller: 'users', format: 'json' do
         put :avatar_image, controller: 'images', action: 'update_avatar_image', format: 'json'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,9 @@ Rails.application.routes.draw do
         resources :sessions, only: [:index], format: 'json'
       end
 
-      resources :users, only: %i[show], format: 'json'
+      resources :users, only: %i[show], format: 'json' do
+        resource :follow, only: %i[create destroy]
+      end
       resource :profile, only: %i[update], controller: 'users', format: 'json' do
         put :avatar_image, controller: 'images', action: 'update_avatar_image', format: 'json'
         put :header_image, controller: 'images', action: 'update_header_image', format: 'json'

--- a/db/migrate/20231020233950_create_follows.rb
+++ b/db/migrate/20231020233950_create_follows.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class CreateFollows < ActiveRecord::Migration[7.0]
+  def change
+    create_table :follows do |t|
+      t.references :follower_user, null: false, foreign_key: { to_table: :users }
+      t.references :followed_user, null: false, foreign_key: { to_table: :users }
+
+      t.timestamps
+    end
+    add_index :follows, %i[follower_user_id followed_user_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_10_16_042434) do
+ActiveRecord::Schema[7.0].define(version: 2023_10_20_233950) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -60,6 +60,16 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_16_042434) do
     t.index ["tweet_id", "user_id"], name: "index_favorites_on_tweet_id_and_user_id", unique: true
     t.index ["tweet_id"], name: "index_favorites_on_tweet_id"
     t.index ["user_id"], name: "index_favorites_on_user_id"
+  end
+
+  create_table "follows", force: :cascade do |t|
+    t.bigint "follower_user_id", null: false
+    t.bigint "followed_user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["followed_user_id"], name: "index_follows_on_followed_user_id"
+    t.index ["follower_user_id", "followed_user_id"], name: "index_follows_on_follower_user_id_and_followed_user_id", unique: true
+    t.index ["follower_user_id"], name: "index_follows_on_follower_user_id"
   end
 
   create_table "retweets", force: :cascade do |t|
@@ -116,6 +126,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_16_042434) do
   add_foreign_key "comments", "users"
   add_foreign_key "favorites", "tweets"
   add_foreign_key "favorites", "users"
+  add_foreign_key "follows", "users", column: "followed_user_id"
+  add_foreign_key "follows", "users", column: "follower_user_id"
   add_foreign_key "retweets", "tweets"
   add_foreign_key "retweets", "users"
   add_foreign_key "tweets", "users"

--- a/spec/requests/api/v1/tweets_spec.rb
+++ b/spec/requests/api/v1/tweets_spec.rb
@@ -3,12 +3,22 @@
 require 'rails_helper'
 
 RSpec.describe 'Api::V1::Tweets', type: :request do
+  let!(:user) { FactoryBot.create(:user) }
+
   # 認証をスキップさせる
   before do
     allow_any_instance_of(Api::V1::TweetsController).to receive(:authenticate_api_v1_user!).and_return(true)
+
+    # 認証情報をヘッダーに付与する
+    auth_token = user.create_new_auth_token
+    headers['access-token'] = auth_token['access-token']
+    headers['client'] = auth_token['client']
+    headers['uid'] = auth_token['uid']
   end
 
   describe 'GET /api/v1/tweets' do
+    let!(:user) { FactoryBot.create(:user) }
+
     before do
       FactoryBot.create_list(:tweet, 20)
     end
@@ -32,16 +42,7 @@ RSpec.describe 'Api::V1::Tweets', type: :request do
   describe 'POST /api/v1/tweets' do
     subject { post(api_v1_tweets_path, headers:, params:) }
 
-    let!(:user) { FactoryBot.create(:user) }
     let!(:params) { { tweet: 'テストツイート' } }
-
-    # 認証情報をヘッダーに付与する
-    before do
-      auth_token = user.create_new_auth_token
-      headers['access-token'] = auth_token['access-token']
-      headers['client'] = auth_token['client']
-      headers['uid'] = auth_token['uid']
-    end
 
     it 'ツイートが投稿できること' do
       subject


### PR DESCRIPTION
## 課題のリンク

* https://github.com/happiness-chain/practice/blob/main/14.2_react/003_%E8%AA%B2%E9%A1%8C.md#%E3%83%95%E3%82%A9%E3%83%AD%E3%83%BC

## やったこと

* フォローAPIを追加しました
* フォロー解除APIを追加しました

## 動作確認方法

* 動作確認はフロント実装後でも良さそう
* ローカルで確認するなら

```
curl -X POST 'http://localhost:3100/api/v1/users/:user_id/follow' \
-H 'Content-Type: application/json' \
-H 'access-token: <Cookieから取得してください>' \
-H 'client: <Cookieから取得してください>' \
-H 'uid: <Cookieから取得してください>'
```

```
curl -X POST 'http://localhost:3100/api/v1/users/:user_id/unfollow' \
-H 'Content-Type: application/json' \
-H 'access-token: <Cookieから取得してください>' \
-H 'client: <Cookieから取得してください>' \
-H 'uid: <Cookieから取得してください>'
```

## その他

* なし
