### PR TITLE
[fix] グループ取得APIの成功時に200を返すようにする

### DIFF
--- a/app/controllers/api/v1/groups_controller.rb
+++ b/app/controllers/api/v1/groups_controller.rb
@@ -18,7 +18,7 @@ module Api
 
         group = current_api_v1_user.find_or_create_group(user)
 
-        render json: { group: }, status: :created
+        render json: { group: }, status: :ok
       end
 
       private


### PR DESCRIPTION
## 課題のリンク

* なし

## やったこと

* グループ取得APIの成功時に201が返されているので、200を返すようにする

## 動作確認方法

* なし

## その他

* レビュワーへの参考情報（実装上の懸念点や注意点、困りごとなど）
