### PR TITLE
退会APIの追加とセッション情報取得APIの変更

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -34,3 +34,5 @@ RSpec/AnyInstance:
     - "spec/**/*"
 RSpec/LetSetup:
   Enabled: false
+Rails/LexicallyScopedActionFilter:
+  Enabled: false

--- a/app/controllers/api/v1/auth/registrations_controller.rb
+++ b/app/controllers/api/v1/auth/registrations_controller.rb
@@ -4,6 +4,14 @@ module Api
   module V1
     module Auth
       class RegistrationsController < DeviseTokenAuth::RegistrationsController
+        def destroy
+          if current_api_v1_user.logical_delete
+            render json: {}, status: :ok
+          else
+            render json: { errors: 'アカウント削除に失敗しました。' }, status: :unprocessable_entity
+          end
+        end
+
         private
 
         def sign_up_params

--- a/app/controllers/api/v1/auth/sessions_controller.rb
+++ b/app/controllers/api/v1/auth/sessions_controller.rb
@@ -3,9 +3,14 @@
 module Api
   module V1
     module Auth
-      class SessionsController < ApplicationController
-        def index
-          @user = current_api_v1_user
+      class SessionsController < DeviseTokenAuth::SessionsController
+        before_action :reject_user, only: [:create]
+
+        private
+      
+        def reject_user
+          user = User.find_by(email: params[:email]&.downcase)
+          render json: { errors: 'アカウントが無効です。' }, status: :unprocessable_entity if user&.deleted_at.present?
         end
       end
     end

--- a/app/controllers/api/v1/auth/sessions_controller.rb
+++ b/app/controllers/api/v1/auth/sessions_controller.rb
@@ -7,7 +7,7 @@ module Api
         before_action :reject_user, only: [:create]
 
         private
-      
+
         def reject_user
           user = User.find_by(email: params[:email]&.downcase)
           render json: { errors: 'アカウントが無効です。' }, status: :unprocessable_entity if user&.deleted_at.present?

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -29,7 +29,7 @@ module Api
         end
 
         avatar_image_url = current_api_v1_user&.avatar_image&.attached? ? Rails.application.routes.url_helpers.url_for(current_api_v1_user.avatar_image) : nil
-        user = current_api_v1_user&.as_json&.merge(avatar_image_url: avatar_image_url)
+        user = current_api_v1_user&.as_json&.merge(avatar_image_url:)
 
         render json: user, status: :ok
       end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -4,7 +4,7 @@ module Api
   module V1
     class UsersController < ApplicationController
       include Pagination
-      before_action :authenticate_api_v1_user!, only: %i[show]
+      before_action :authenticate_api_v1_user!, only: %i[show update]
 
       def show
         @user = User.find(params[:id])
@@ -20,6 +20,18 @@ module Api
         else
           render json: @user.errors, status: :unprocessable_entity
         end
+      end
+
+      def user_session
+        if current_api_v1_user.deleted_at.present?
+          render json: nil, status: :forbidden
+          return
+        end
+
+        avatar_image_url = current_api_v1_user&.avatar_image&.attached? ? Rails.application.routes.url_helpers.url_for(current_api_v1_user.avatar_image) : nil
+        user = current_api_v1_user&.as_json&.merge(avatar_image_url: avatar_image_url)
+
+        render json: user, status: :ok
       end
 
       private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -28,6 +28,14 @@ class User < ApplicationRecord
   # TODO: サインイン時にallow_blankが適応されずバリデーションエラーとなるので一旦コメントアウト
   # validates :website_url, format: /\A#{URI::DEFAULT_PARSER.make_regexp(%w[http https])}\z/, allow_blank: true
 
+  def logical_delete
+    update(deleted_at: Time.current)
+  end
+
+  def logical_deleted?
+    deleted_at.present?
+  end
+
   def same?(user)
     id == user.id
   end

--- a/app/views/api/v1/auth/sessions/index.json.jbuilder
+++ b/app/views/api/v1/auth/sessions/index.json.jbuilder
@@ -1,4 +1,0 @@
-# frozen_string_literal: true
-
-json.extract! @user, :id, :email, :name, :nickname
-json.avatar_image_url @user.avatar_image.attached? ? Rails.application.routes.url_helpers.url_for(@user.avatar_image) : nil

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
     namespace :v1 do
       mount_devise_token_auth_for 'User', at: 'users', controllers: {
         registrations: 'api/v1/auth/registrations',
-        sessions: 'api/v1/auth/sessions',
+        sessions: 'api/v1/auth/sessions'
       }
       get :user_session, to: 'users#user_session', format: 'json'
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,11 +6,10 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       mount_devise_token_auth_for 'User', at: 'users', controllers: {
-        registrations: 'api/v1/auth/registrations'
+        registrations: 'api/v1/auth/registrations',
+        sessions: 'api/v1/auth/sessions',
       }
-      namespace :auth do
-        resources :sessions, only: [:index], format: 'json'
-      end
+      get :user_session, to: 'users#user_session', format: 'json'
 
       resources :users, only: %i[show], format: 'json' do
         post :follow, to: 'follows#create'

--- a/db/migrate/20231028094549_add_deleted_at_to_users.rb
+++ b/db/migrate/20231028094549_add_deleted_at_to_users.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddDeletedAtToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :deleted_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_10_23_122942) do
+ActiveRecord::Schema[7.0].define(version: 2023_10_28_094549) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -158,6 +158,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_23_122942) do
     t.date "birthdate"
     t.string "location", limit: 10
     t.string "introduction", limit: 100
+    t.datetime "deleted_at"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["name"], name: "index_users_on_name", unique: true


### PR DESCRIPTION
## 課題のリンク

* https://github.com/happiness-chain/practice/blob/main/14.2_react/003_%E8%AA%B2%E9%A1%8C.md#%E9%80%80%E4%BC%9A

## やったこと

* 退会APIを追加した
* 退会済みユーザーがログインしたときに、エラーになるようにした
* 退会済みユーザーはセッション情報取得時にエラーになるようにした
* セッション情報取得APIのコントローラの名前が devise のものと被っていたので、`User#user_session` に移行した

## 動作確認方法

### 準備

1. [会員登録画面](https://8tako8tako8.github.io/twitter_react/registration) または [ログイン画面](https://8tako8tako8.github.io/twitter_react/login)にアクセスし、ログインする

### 動作確認

* herokuで確認する場合は https://twitter-rails-api1-a77730c5e74f.herokuapp.com に差し替えてください
* ✅ 退会できること

```
curl -X DELETE 'http://localhost:3100/api/v1/users' \
-H 'Content-Type: application/json' \
-H 'access-token: <Cookieから取得してください>' \
-H 'client: <Cookieから取得してください>' \
-H 'uid: <Cookieから取得してください>'
```

## その他

* なし
